### PR TITLE
Improve sample code

### DIFF
--- a/fquery/mock_user.py
+++ b/fquery/mock_user.py
@@ -19,11 +19,18 @@ class MockUser(ViewModel):
     async def friends(self) -> List["MockUser"]:
         yield [MockUser.get(m) for m in range(3 * self.id, 3 * self.id + 3)]
 
+    @edge
+    async def reviews(self) -> List["MockReview"]:
+        yield [
+            MockReview.get(m) for m in range(3 * self.id + 300, 3 * self.id + 300 + 5)
+        ]
+
     @staticmethod
     def get(id: int) -> "MockUser":
         # A typical implementation may fetch fields from a database
         # based on self.id here
         u = MockUser(id=id, name=f"id{id}", age=random.choice([16, 17, 18]))
+        u._type = 1
         return u
 
 
@@ -38,5 +45,37 @@ class UserQuery(Query):
         return MockUser.get(_id)
 
 
+@dataclass
+class MockReview(ViewModel):
+    business: str
+    rating: int
+    author: MockUser
+
+    @edge
+    async def author(self) -> MockUser:
+        yield self.author
+
+    @staticmethod
+    def get(id: int) -> "MockReview":
+        # A typical implementation may fetch fields from a database
+        # based on self.id here
+        r = MockReview(
+            id=id, business=f"business{id}", rating=random.choice(range(1, 6))
+        )
+        r._type = 2
+        return r
+
+
+class ReviewQuery(Query):
+    OP = QueryableOp.LEAF
+
+    def __init__(self, ids=None, items=None):
+        super().__init__(None, ids, items)
+
+    @staticmethod
+    def resolve_obj(_id: int, edge: str = "") -> Optional[ViewModel]:
+        return MockReview.get(_id)
+
+
 # TODO: Handle this via @edge decorator
-UserQuery.EDGE_NAME_TO_QUERY_TYPE = {"friends": UserQuery}
+UserQuery.EDGE_NAME_TO_QUERY_TYPE = {"friends": UserQuery, "reviews": ReviewQuery}

--- a/fquery/view_model.py
+++ b/fquery/view_model.py
@@ -49,3 +49,21 @@ class ViewModel(OrderedDict):
     def __setattr__(self, name, value):
         super().__setattr__(name, value)
         self.__setitem__(name, value)
+
+    async def resolve_edge(self, edge_name: str, edge_ctx):
+        async for i in self.__getattribute__(edge_name)():
+            yield i
+
+
+def edge(fn):
+    def decorated(*args, **kwargs):
+        function_instance = fn(*args, **kwargs)
+
+        async def inner():
+            async for v in function_instance:
+                yield v
+
+        return inner()
+
+    # Populate EDGE_NAME_TO_QUERY_TYPE here
+    return decorated

--- a/fquery/view_model.py
+++ b/fquery/view_model.py
@@ -4,15 +4,22 @@
 # LICENSE file in the root directory of this source tree.
 # Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
 from collections import OrderedDict
+from dataclasses import dataclass
 
 
+@dataclass
 class ViewModel(OrderedDict):
     """Like an OrderedDict, but treats :id as special for
        equality purposes and hashable (so you can create sets).
     """
 
+    id: int
+
     IDKEY = ":id"
     TYPE_KEY = ":type"
+
+    def __init__(self, other_dict):
+        super().__init__(other_dict)
 
     def __lt__(self, other):
         return self[ViewModel.IDKEY] < other[ViewModel.IDKEY]
@@ -38,3 +45,7 @@ class ViewModel(OrderedDict):
         elif name == "_type":
             name = ViewModel.TYPE_KEY
         super().__setitem__(name, value)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        self.__setitem__(name, value)

--- a/tests/test_data/test_data_edge_project.txt
+++ b/tests/test_data/test_data_edge_project.txt
@@ -3,84 +3,48 @@
         "None": [
             {
                 ":id": 1,
-                ":type": 1,
-                "age": 17,
-                "friends": [
-                    {
-                        ":id": 3,
-                        "name": "id3"
-                    },  
-                    {
-                        ":id": 4,
-                        "name": "id4"
-                    },  
-                    {
-                        ":id": 5,
-                        "name": "id5"
-                    }
-                ],
-                "name": "id1"
-            },
-            {   
-                ":id": 2,
-                ":type": 2,
+                "name": "id1",
                 "age": 16,
+                ":type": 1,
                 "friends": [
-                    {   
-                        ":id": 6,
-                        "name": "id6"
-                    },
-                    {   
-                        ":id": 7,
-                        "name": "id7"
-                    },
-                    {   
-                        ":id": 8,
-                        "name": "id8"
-                    }
+                    {"name": "id3", ":id": 3},
+                    {"name": "id4", ":id": 4},
+                    {"name": "id5", ":id": 5},
                 ],
-                "name": "id2"
             },
-            {   
-                ":id": 3,       
-                ":type": 2,
-                "age": 18,
-                "friends": [
-                    {   
-                        ":id": 9,
-                        "name": "id9"
-                    },  
-                    {   
-                        ":id": 10,
-                        "name": "id10"
-                    },
-                    {   
-                        ":id": 11,
-                        "name": "id11"
-                    }
-                ],
-                "name": "id3"
-            },
-            {   
-                ":id": 4,
-                ":type": 2,
+            {
+                ":id": 2,
+                "name": "id2",
                 "age": 17,
+                ":type": 1,
                 "friends": [
-                    {   
-                        ":id": 12,
-                        "name": "id12"
-                    },
-                    {   
-                        ":id": 13,
-                        "name": "id13"
-                    },
-                    {   
-                        ":id": 14,
-                        "name": "id14"
-                    }
+                    {"name": "id6", ":id": 6},
+                    {"name": "id7", ":id": 7},
+                    {"name": "id8", ":id": 8},
                 ],
-                "name": "id4"
-            }
+            },
+            {
+                ":id": 3,
+                "name": "id3",
+                "age": 17,
+                ":type": 1,
+                "friends": [
+                    {"name": "id9", ":id": 9},
+                    {"name": "id10", ":id": 10},
+                    {"name": "id11", ":id": 11},
+                ],
+            },
+            {
+                ":id": 4,
+                "name": "id4",
+                "age": 16,
+                ":type": 1,
+                "friends": [
+                    {"name": "id12", ":id": 12},
+                    {"name": "id13", ":id": 13},
+                    {"name": "id14", ":id": 14},
+                ],
+            },
         ]
     }
 ]

--- a/tests/test_data/test_data_edge_project_other_kind.txt
+++ b/tests/test_data/test_data_edge_project_other_kind.txt
@@ -1,0 +1,50 @@
+[
+    {
+        "None": [
+            {
+                ":id": 1,
+                "name": "id1",
+                "age": 16,
+                ":type": 1,
+                "reviews": [
+                    {"business": "business303", "rating": 4, ":id": 303},
+                    {"business": "business304", "rating": 3, ":id": 304},
+                    {"business": "business305", "rating": 4, ":id": 305},
+                ],
+            },
+            {
+                ":id": 2,
+                "name": "id2",
+                "age": 17,
+                ":type": 1,
+                "reviews": [
+                    {"business": "business306", "rating": 5, ":id": 306},
+                    {"business": "business307", "rating": 1, ":id": 307},
+                    {"business": "business308", "rating": 1, ":id": 308},
+                ],
+            },
+            {
+                ":id": 3,
+                "name": "id3",
+                "age": 17,
+                ":type": 1,
+                "reviews": [
+                    {"business": "business309", "rating": 1, ":id": 309},
+                    {"business": "business310", "rating": 2, ":id": 310},
+                    {"business": "business311", "rating": 3, ":id": 311},
+                ],
+            },
+            {
+                ":id": 4,
+                "name": "id4",
+                "age": 16,
+                ":type": 1,
+                "reviews": [
+                    {"business": "business312", "rating": 2, ":id": 312},
+                    {"business": "business313", "rating": 2, ":id": 313},
+                    {"business": "business314", "rating": 2, ":id": 314},
+                ],
+            },
+        ]
+    }
+]

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -164,7 +164,7 @@ class QueryTests(unittest.TestCase):
         resp = (
             await UserQuery(range(1, 4)).where(ast.Expr("user.age == 16")).to_json()
         )
-        expected = [{"None": [{":id": 2, "name": "id2", ":type": 2, "age": 16}]}]
+        expected = [{"None": [{":id": 1, "name": "id1", ":type": 2, "age": 16}]}]
         self.assertEqual(expected, resp)
 
     @async_test
@@ -173,8 +173,8 @@ class QueryTests(unittest.TestCase):
         expected = [
             {
                 "None": [
-                    {":id": 2, "name": "id2", ":type": 2, "age": 16},
-                    {":id": 1, "name": "id1", ":type": 1, "age": 17},
+                    {":id": 1, "name": "id1", ":type": 2, "age": 16},
+                    {":id": 2, "name": "id2", ":type": 1, "age": 17},
                     {":id": 3, "name": "id3", ":type": 2, "age": 18},
                 ]
             }

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -58,6 +58,23 @@ class QueryTests(unittest.TestCase):
         with open(os.path.join(TEST_DATA, "test_data_edge_project.txt")) as f:
             expected = ast.literal_eval(f.read())
         self.assertEqual(expected, resp)
+        self.assertEqual(str(expected), str(resp))
+
+    @async_test
+    async def test_edge_project_other_kind(self):
+        resp = (
+            await UserQuery(range(1, 5))
+            .edge("reviews")
+            .project(["business", "rating", ":id"])
+            .take(3)
+            .to_json()
+        )
+        with open(
+            os.path.join(TEST_DATA, "test_data_edge_project_other_kind.txt")
+        ) as f:
+            expected = ast.literal_eval(f.read())
+        self.assertEqual(expected, resp)
+        self.assertEqual(str(expected), str(resp))
 
     def test_sync_edge_project(self):
         resp = (
@@ -161,9 +178,7 @@ class QueryTests(unittest.TestCase):
 
     @async_test
     async def test_where(self):
-        resp = (
-            await UserQuery(range(1, 4)).where(ast.Expr("user.age == 16")).to_json()
-        )
+        resp = await UserQuery(range(1, 4)).where(ast.Expr("user.age == 16")).to_json()
         expected = [{"None": [{":id": 1, "name": "id1", ":type": 2, "age": 16}]}]
         self.assertEqual(expected, resp)
 


### PR DESCRIPTION
These commits demonstrate how to use a combination of `@dataclass` and `@edge` decorators to specify a schema.
Add a test case for heterogeneous graph navigation (`MockUser` -> `MockReview`)

The implementation might have lost some parallelism though - `asyncio.gather` replaced by two nested async for loops. It was easier to debug and read, but the overall performance may be worse than the code before. Left a TODO on improving the parallelism.